### PR TITLE
[Fix] Add VSCode-specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+
+# VSCode-specific ignores
+.vscode/


### PR DESCRIPTION
The `vscode` extension `godot-tools` writes the system-specific location of the language server to the `.vscode` directory. Because this directory contains user configuration, it's best to remove it from the working tree.